### PR TITLE
fix: Remove all old container code paths

### DIFF
--- a/controller/session_wrapper.sh
+++ b/controller/session_wrapper.sh
@@ -77,7 +77,6 @@ echo \$$ > ${job_number}.pid
 
 # These are not workflow parameters but need to be available to the service on the remote node!
 FORWARDPATH=${FORWARDPATH}
-NEW_USERCONTAINER=${NEW_USERCONTAINER}
 IPADDRESS=${IPADDRESS}
 openPort=${openPort}
 USER_CONTAINER_HOST=${USER_CONTAINER_HOST}

--- a/jupyter-docker/start-template.sh
+++ b/jupyter-docker/start-template.sh
@@ -65,48 +65,26 @@ def load_jupyter_server_extension(nbapp):
     web_app.add_handlers('.*', handlers)
 HERE
 
-if [[ "$NEW_USERCONTAINER" == "0" ]];then
-    # Served from 
-    # https://cloud.parallel.works/api/v2/proxy/usercontainer?proxyType=api&proxyTo=/api/v1/display/pw/jobs/57147/service.html
-    export PYTHONPATH=${PWD}
-    sudo -n docker run ${gpu_flag} --rm \
-        -v /contrib:/contrib -v /lustre:/lustre -v ${HOME}:${HOME} \
-        --name=jupyter-$servicePort \
-        -p $servicePort:$servicePort \
-        __docker_repo__ jupyter-notebook \
-            --port=${servicePort} \
-            --ip=0.0.0.0 \
-            --NotebookApp.default_url="/me/${openPort}/tree" \
-            --NotebookApp.iopub_data_rate_limit=10000000000 \
-            --NotebookApp.token= \
-            --NotebookApp.password=$sha \
-            --no-browser \
-            --notebook-dir=$notebook_dir \
-            --NotebookApp.nbserver_extensions "pw_jupyter_proxy=True" \
-            --NotebookApp.tornado_settings="{\"static_url_prefix\":\"/me/${openPort}/static/\"}" \
-            --NotebookApp.allow_origin=*
 
-else
-    # Served from:
-    # https://noaa.parallel.works /pwide-nb/noaa-user-1.parallel.works/50359/ tree?dt=1670280530105
-    # https://cloud.parallel.work /api/v2/proxy/usercontainer?proxyType=api&proxyTo=/api/v1/display/pw/jobs/57147/ service.html
-    sudo -n docker run ${gpu_flag} --rm \
-        -v /contrib:/contrib -v /lustre:/lustre -v ${HOME}:${HOME} \
-        --name=jupyter-$servicePort \
-        -p $servicePort:$servicePort \
-        __docker_repo__ jupyter-notebook \
-            --port=$servicePort \
-            --ip=0.0.0.0 \
-            --NotebookApp.iopub_data_rate_limit=10000000000 \
-            --NotebookApp.token= \
-            --NotebookApp.password=$sha \
-            --no-browser \
-            --notebook-dir=$notebook_dir \
-            --NotebookApp.tornado_settings="{'static_url_prefix':'/${FORWARDPATH}/${IPADDRESS}/${openPort}/static/'}" \
-            --NotebookApp.base_url="/${FORWARDPATH}/${IPADDRESS}/${openPort}/" \
-            --NotebookApp.allow_origin=*
-    
-fi
+# Served from 
+# https://cloud.parallel.works/api/v2/proxy/usercontainer?proxyType=api&proxyTo=/api/v1/display/pw/jobs/57147/service.html
+export PYTHONPATH=${PWD}
+sudo -n docker run ${gpu_flag} --rm \
+    -v /contrib:/contrib -v /lustre:/lustre -v ${HOME}:${HOME} \
+    --name=jupyter-$servicePort \
+    -p $servicePort:$servicePort \
+    __docker_repo__ jupyter-notebook \
+        --port=${servicePort} \
+        --ip=0.0.0.0 \
+        --NotebookApp.default_url="/me/${openPort}/tree" \
+        --NotebookApp.iopub_data_rate_limit=10000000000 \
+        --NotebookApp.token= \
+        --NotebookApp.password=$sha \
+        --no-browser \
+        --notebook-dir=$notebook_dir \
+        --NotebookApp.nbserver_extensions "pw_jupyter_proxy=True" \
+        --NotebookApp.tornado_settings="{\"static_url_prefix\":\"/me/${openPort}/static/\"}" \
+        --NotebookApp.allow_origin=*
 
 sleep 9999
 

--- a/jupyter-host/start-template.sh
+++ b/jupyter-host/start-template.sh
@@ -100,39 +100,22 @@ def load_jupyter_server_extension(nbapp):
     web_app.add_handlers('.*', handlers)
 HERE
 
-if [[ "$NEW_USERCONTAINER" == "0" ]];then
-    # Served from 
-    # https://cloud.parallel.works/api/v2/proxy/usercontainer?proxyType=api&proxyTo=/api/v1/display/pw/jobs/57147/service.html
-    export PYTHONPATH=${PWD}
-    jupyter-notebook \
-        --port=${servicePort} \
-        --ip=0.0.0.0 \
-        --NotebookApp.default_url="/me/${openPort}/tree" \
-        --NotebookApp.iopub_data_rate_limit=10000000000 \
-        --NotebookApp.token= \
-        --NotebookApp.password=$sha \
-        --no-browser \
-        --notebook-dir=$notebook_dir \
-        --NotebookApp.nbserver_extensions "pw_jupyter_proxy=True" \
-        --NotebookApp.tornado_settings="{\"static_url_prefix\":\"/me/${openPort}/static/\"}" \
-        --NotebookApp.allow_origin=*
+# Served from 
+# https://cloud.parallel.works/api/v2/proxy/usercontainer?proxyType=api&proxyTo=/api/v1/display/pw/jobs/57147/service.html
+export PYTHONPATH=${PWD}
+jupyter-notebook \
+    --port=${servicePort} \
+    --ip=0.0.0.0 \
+    --NotebookApp.default_url="/me/${openPort}/tree" \
+    --NotebookApp.iopub_data_rate_limit=10000000000 \
+    --NotebookApp.token= \
+    --NotebookApp.password=$sha \
+    --no-browser \
+    --notebook-dir=$notebook_dir \
+    --NotebookApp.nbserver_extensions "pw_jupyter_proxy=True" \
+    --NotebookApp.tornado_settings="{\"static_url_prefix\":\"/me/${openPort}/static/\"}" \
+    --NotebookApp.allow_origin=*
 
-else
-    # Served from:
-    # https://noaa.parallel.works /pwide-nb/noaa-user-1.parallel.works/50359/ tree?dt=1670280530105
-    # https://cloud.parallel.work /api/v2/proxy/usercontainer?proxyType=api&proxyTo=/api/v1/display/pw/jobs/57147/ service.html
-    jupyter-notebook \
-        --port=$servicePort \
-        --ip=0.0.0.0 \
-        --NotebookApp.iopub_data_rate_limit=10000000000 \
-        --NotebookApp.token= \
-        --NotebookApp.password=$sha \
-        --no-browser \
-        --notebook-dir=$notebook_dir \
-        --NotebookApp.tornado_settings="{'static_url_prefix':'/${FORWARDPATH}/${IPADDRESS}/${openPort}/static/'}" \
-        --NotebookApp.base_url="/${FORWARDPATH}/${IPADDRESS}/${openPort}/" \
-        --NotebookApp.allow_origin=*
-    
-fi
+
 
 sleep 9999

--- a/jupyter-singularity/start-template.sh
+++ b/jupyter-singularity/start-template.sh
@@ -80,43 +80,22 @@ def load_jupyter_server_extension(nbapp):
     web_app.add_handlers('.*', handlers)
 HERE
 
-if [[ "$NEW_USERCONTAINER" == "0" ]];then
-    # Served from 
-    # https://cloud.parallel.works/api/v2/proxy/usercontainer?proxyType=api&proxyTo=/api/v1/display/pw/jobs/57147/service.html
-    export PYTHONPATH=${PWD}
-    singularity exec ${gpu_flag} \
-        ${mount_dirs} \
-        ${path_to_sing} \
-        jupyter-notebook \
-            --port=${servicePort} \
-            --ip=0.0.0.0 \
-            --NotebookApp.default_url="/me/${openPort}/tree" \
-            --NotebookApp.iopub_data_rate_limit=10000000000 \
-            --NotebookApp.token= \
-            --NotebookApp.password=$sha \
-            --no-browser \
-            --notebook-dir=$notebook_dir \
-            --NotebookApp.nbserver_extensions "pw_jupyter_proxy=True" \
-            --NotebookApp.tornado_settings="{\"static_url_prefix\":\"/me/${openPort}/static/\"}" \
-            --NotebookApp.allow_origin=*
 
-else
-    # Served from:
-    # https://noaa.parallel.works /pwide-nb/noaa-user-1.parallel.works/50359/ tree?dt=1670280530105
-    # https://cloud.parallel.work /api/v2/proxy/usercontainer?proxyType=api&proxyTo=/api/v1/display/pw/jobs/57147/ service.html
-    singularity exec ${gpu_flag} \
-        ${mount_dirs} \
-        ${path_to_sing} \
-        jupyter-notebook \
-            --port=$servicePort \
-            --ip=0.0.0.0 \
-            --NotebookApp.iopub_data_rate_limit=10000000000 \
-            --NotebookApp.token= \
-            --NotebookApp.password=$sha \
-            --no-browser \
-            --notebook-dir=$notebook_dir \
-            --NotebookApp.tornado_settings="{'static_url_prefix':'/${FORWARDPATH}/${IPADDRESS}/${openPort}/static/'}" \
-            --NotebookApp.base_url="/${FORWARDPATH}/${IPADDRESS}/${openPort}/" \
-            --NotebookApp.allow_origin=*
-    
-fi
+# Served from 
+# https://cloud.parallel.works/api/v2/proxy/usercontainer?proxyType=api&proxyTo=/api/v1/display/pw/jobs/57147/service.html
+export PYTHONPATH=${PWD}
+singularity exec ${gpu_flag} \
+    ${mount_dirs} \
+    ${path_to_sing} \
+    jupyter-notebook \
+        --port=${servicePort} \
+        --ip=0.0.0.0 \
+        --NotebookApp.default_url="/me/${openPort}/tree" \
+        --NotebookApp.iopub_data_rate_limit=10000000000 \
+        --NotebookApp.token= \
+        --NotebookApp.password=$sha \
+        --no-browser \
+        --notebook-dir=$notebook_dir \
+        --NotebookApp.nbserver_extensions "pw_jupyter_proxy=True" \
+        --NotebookApp.tornado_settings="{\"static_url_prefix\":\"/me/${openPort}/static/\"}" \
+        --NotebookApp.allow_origin=*

--- a/local/session_wrapper.sh
+++ b/local/session_wrapper.sh
@@ -35,7 +35,6 @@ echo \$$ > ${job_number}.pid
 
 # These are not workflow parameters but need to be available to the service on the remote node!
 FORWARDPATH=${FORWARDPATH}
-NEW_USERCONTAINER=${NEW_USERCONTAINER}
 IPADDRESS=${IPADDRESS}
 openPort=${openPort}
 USER_CONTAINER_HOST=${USER_CONTAINER_HOST}

--- a/main.sh
+++ b/main.sh
@@ -194,24 +194,14 @@ else
 fi
 
 # SERVICE URL
-# FIXME: This entire section needs cleaning. Got dirty with the new usercontainer.
-# check if the user is on a new container 
-env | grep -q PW_USERCONTAINER_VERSION
-# Needs to be exported for services like Jupyter that require a base url --NotebookApp.base_url
-export NEW_USERCONTAINER="$?"
 
 echo "Generating session html"
 replace_templated_inputs ${service_name}/url.sh $wfargs
 source ${service_name}/url.sh
 cp service.html.template service.html_
 
-if [[ "$NEW_USERCONTAINER" == "0" ]];then
-    URL="\"/me/${openPort}/${URLEND}"
-    sed -i "s|.*URL.*|    \"URL\": \"/me\",|" service.json
-else
-    URL="\"/${FORWARDPATH}/${IPADDRESS}/${openPort}/${URLEND}"
-    sed -i "s|.*URL.*|    \"URL\": \"/${FORWARDPATH}/${IPADDRESS}\",|" service.json
-fi
+URL="\"/me/${openPort}/${URLEND}"
+sed -i "s|.*URL.*|    \"URL\": \"/me\",|" service.json
 sed -i "s|__URL__|${URL}|g" service.html_
 # JSON values cannot contain quotes "
 #URL_JSON=$(echo ${URL} | sed 's|\"|\\\\\"|g')

--- a/matlab-docker/start-template.sh
+++ b/matlab-docker/start-template.sh
@@ -20,11 +20,7 @@ chmod 777 docker-kill-${job_number}.sh
 
 sudo -n systemctl start docker
 
-if [[ "$NEW_USERCONTAINER" == "0" ]];then
-    MWI_BASE_URL="/me/${openPort}/"
-else
-    MWI_BASE_URL="/${FORWARDPATH}/${IPADDRESS}/${openPort}/" 
-fi
+MWI_BASE_URL="/me/${openPort}/"
 
 # Docker supports mounting directories that do not exist (singularity does not)
 set -x

--- a/partition/session_wrapper.sh
+++ b/partition/session_wrapper.sh
@@ -90,7 +90,6 @@ if [ -f "${remote_sh}" ]; then
 fi
 
 # These are not workflow parameters but need to be available to the service on the remote node!
-NEW_USERCONTAINER=${NEW_USERCONTAINER}
 FORWARDPATH=${FORWARDPATH}
 IPADDRESS=${IPADDRESS}
 openPort=${openPort}

--- a/turbovnc/url.sh
+++ b/turbovnc/url.sh
@@ -6,8 +6,5 @@ else
     export IPADDRESS="$PW_USER_HOST"
 fi
 
-if [[ "$NEW_USERCONTAINER" == "0" ]];then
-    export URLEND="vnc.html?resize=remote\&autoconnect=true\&show_dot=true\&path=websockify\&password=headless\&host=\"+window.location.host+\"/me/${openPort}\"+\"\/\&dt=\"+(new Date()).getTime()"
-else
-    export URLEND="vnc.html?resize=remote\&autoconnect=true\&show_dot=true\&path=websockify\&password=headless\&host=\"+window.location.host+\"/${FORWARDPATH}/${IPADDRESS}/${openPort}\"+\"\/\&dt=\"+(new Date()).getTime()"
-fi
+
+export URLEND="vnc.html?resize=remote\&autoconnect=true\&show_dot=true\&path=websockify\&password=headless\&host=\"+window.location.host+\"/me/${openPort}\"+\"\/\&dt=\"+(new Date()).getTime()"


### PR DESCRIPTION
This PR removes all checks for the new user container, as we have already completely migrated to the new user container on all platforms. 