### PR TITLE
Added --export=ALL;--get-user-env to all noVNC emed forms

### DIFF
--- a/workflow/xmls/turbovnc/fsl-emed-onprem.xml
+++ b/workflow/xmls/turbovnc/fsl-emed-onprem.xml
@@ -23,7 +23,7 @@
             </param>   
             <param name='_pw__sch__dd_time_e_' label='Walltime' type='text' help='e.g. 01:00:00 - Amount of time slurm will honor the interactive session.' value='01:00:00' width='50%_none'>
             </param>
-            <param name='_pw_scheduler_directives' label='Scheduler directives' type='text' help='e.g. --mem=1000;--gpus-per-node=1 - Use the semicolon character ; to separate parameters. Do not include the SBATCH keyword.' value='' width='100%_none'>
+            <param name='_pw_scheduler_directives' label='Scheduler directives' type='text' help='e.g. --mem=1000;--gpus-per-node=1 - Use the semicolon character ; to separate parameters. Do not include the SBATCH keyword.' value='--get-user-env;--export=ALL' width='100%_none'>
             </param>
         </when>
       </conditional>

--- a/workflow/xmls/turbovnc/nextflow-emed-onprem.xml
+++ b/workflow/xmls/turbovnc/nextflow-emed-onprem.xml
@@ -23,7 +23,7 @@
             </param>   
             <param name='_pw__sch__dd_time_e_' label='Walltime' type='text' help='e.g. 01:00:00 - Amount of time slurm will honor the interactive session.' value='01:00:00' width='50%_none'>
             </param>
-            <param name='_pw_scheduler_directives' label='Scheduler directives' type='text' help='e.g. --mem=1000;--gpus-per-node=1 - Use the semicolon character ; to separate parameters. Do not include the SBATCH keyword.' value='' width='100%_none'>
+            <param name='_pw_scheduler_directives' label='Scheduler directives' type='text' help='e.g. --mem=1000;--gpus-per-node=1 - Use the semicolon character ; to separate parameters. Do not include the SBATCH keyword.' value='--get-user-env;--export=ALL' width='100%_none'>
             </param>
         </when>
       </conditional>

--- a/workflow/xmls/turbovnc/novnc-emed-onprem.xml
+++ b/workflow/xmls/turbovnc/novnc-emed-onprem.xml
@@ -19,7 +19,7 @@
             </param>   
             <param name='_pw__sch__dd_time_e_' label='Walltime' type='text' help='e.g. 01:00:00 - Amount of time slurm will honor the interactive session.' value='01:00:00' width='50%_none'>
             </param>
-            <param name='_pw_scheduler_directives' label='Scheduler directives' type='text' help='e.g. --mem=1000;--gpus-per-node=1 - Use the semicolon character ; to separate parameters. Do not include the SBATCH keyword.' value='' width='100%_none'>
+            <param name='_pw_scheduler_directives' label='Scheduler directives' type='text' help='e.g. --mem=1000;--gpus-per-node=1 - Use the semicolon character ; to separate parameters. Do not include the SBATCH keyword.' value='--get-user-env;--export=ALL' width='100%_none'>
             </param>
         </when>
       </conditional>

--- a/workflow/xmls/turbovnc/rstudio-emed-onprem.xml
+++ b/workflow/xmls/turbovnc/rstudio-emed-onprem.xml
@@ -23,7 +23,7 @@
             </param>   
             <param name='_pw__sch__dd_time_e_' label='Walltime' type='text' help='e.g. 01:00:00 - Amount of time slurm will honor the interactive session.' value='01:00:00' width='50%_none'>
             </param>
-            <param name='_pw_scheduler_directives' label='Scheduler directives' type='text' help='e.g. --mem=1000;--gpus-per-node=1 - Use the semicolon character ; to separate parameters. Do not include the SBATCH keyword.' value='' width='100%_none'>
+            <param name='_pw_scheduler_directives' label='Scheduler directives' type='text' help='e.g. --mem=1000;--gpus-per-node=1 - Use the semicolon character ; to separate parameters. Do not include the SBATCH keyword.' value='--get-user-env;--export=ALL' width='100%_none'>
             </param>
         </when>
       </conditional>

--- a/workflow/xmls/turbovnc/schrodinger-emed-onprem.xml
+++ b/workflow/xmls/turbovnc/schrodinger-emed-onprem.xml
@@ -23,7 +23,7 @@
             </param>   
             <param name='_pw__sch__dd_time_e_' label='Walltime' type='text' help='e.g. 01:00:00 - Amount of time slurm will honor the interactive session.' value='01:00:00' width='50%_none'>
             </param>
-            <param name='_pw_scheduler_directives' label='Scheduler directives' type='text' help='e.g. --mem=1000;--gpus-per-node=1 - Use the semicolon character ; to separate parameters. Do not include the SBATCH keyword.' value='' width='100%_none'>
+            <param name='_pw_scheduler_directives' label='Scheduler directives' type='text' help='e.g. --mem=1000;--gpus-per-node=1 - Use the semicolon character ; to separate parameters. Do not include the SBATCH keyword.' value='--get-user-env;--export=ALL' width='100%_none'>
             </param>
         </when>
       </conditional>

--- a/workflow/xmls/turbovnc/vmd-emed-onprem.xml
+++ b/workflow/xmls/turbovnc/vmd-emed-onprem.xml
@@ -23,7 +23,7 @@
             </param>   
             <param name='_pw__sch__dd_time_e_' label='Walltime' type='text' help='e.g. 01:00:00 - Amount of time slurm will honor the interactive session.' value='01:00:00' width='50%_none'>
             </param>
-            <param name='_pw_scheduler_directives' label='Scheduler directives' type='text' help='e.g. --mem=1000;--gpus-per-node=1 - Use the semicolon character ; to separate parameters. Do not include the SBATCH keyword.' value='' width='100%_none'>
+            <param name='_pw_scheduler_directives' label='Scheduler directives' type='text' help='e.g. --mem=1000;--gpus-per-node=1 - Use the semicolon character ; to separate parameters. Do not include the SBATCH keyword.' value='--get-user-env;--export=ALL' width='100%_none'>
             </param>
         </when>
       </conditional>


### PR DESCRIPTION
These SLURM directives are necessary for running on GPU nodes. They are not needed for CPU nodes, but their presence doesn't impact the jobs. Adding these directives resolves the issue that module commands cannot be found when the interactive session is starting up.

I've tested this on CPU and GPU nodes for MATLAB, Rstudio, FSL, Schrodinger, and VMD.