### PR TITLE
Add packages to Jupyter display env for kernel connect

### DIFF
--- a/jupyter-host/start-template.sh
+++ b/jupyter-host/start-template.sh
@@ -39,6 +39,11 @@ if ! [ -z "${conda_sh}" ] && ! [[ "${conda_sh}" == "__""conda_sh""__" ]]; then
         }
         if [ -z $(which ${jupyter-notebook} 2> /dev/null) ]; then
             conda install -c anaconda jupyter -y
+            # For connecting kernels from other envs
+            conda install nb_conda_kernels -y
+            conda install -c anaconda jinja2 -y
+            #conda install requests -y
+            #pip install remote_ikernel
         fi
     fi
 fi


### PR DESCRIPTION
Need to add at least nb_conda_kernels and jinja2 to connect kernels from other Conda envs to the running notebook.

I tested that this change enabled kernel selection on NYU and PW cloud clusters via `cloud.parallel.works`.