### PR TITLE
Initialize user container connection. The first time you run this on …

### DIFF
--- a/partition/session_wrapper.sh
+++ b/partition/session_wrapper.sh
@@ -49,6 +49,7 @@ cd ${resource_jobdir}
 
 echo "Running in host \$(hostname)"
 sshusercontainer="ssh ${resource_ssh_usercontainer_options} -f ${USER_CONTAINER_HOST}"
+ssh ${resource_ssh_usercontainer_options} -f ${USER_CONTAINER_HOST} hostname
 
 displayErrorMessage() {
     echo \$(date): \$1


### PR DESCRIPTION
…some noaa partitions it simply returns Warning: Permanently added '[localhost]:2225' (RSA) to the list of known hosts.