### PR TITLE
load_bucket_credentials returns bucket name

### DIFF
--- a/jupyterlab-host/dask-extension-jupyterlab-demo.ipynb
+++ b/jupyterlab-host/dask-extension-jupyterlab-demo.ipynb
@@ -108,7 +108,7 @@
     {
      "data": {
       "text/plain": [
-       "<distributed.deploy.adaptive.Adaptive at 0x2ab7e9029690>"
+       "<distributed.deploy.adaptive.Adaptive at 0x15254308c9d0>"
       ]
      },
      "execution_count": 4,
@@ -146,7 +146,7 @@
        "    <div style=\"width: 24px; height: 24px; background-color: #e1e1e1; border: 3px solid #9D9D9D; border-radius: 5px; position: absolute;\"> </div>\n",
        "    <div style=\"margin-left: 48px;\">\n",
        "        <h3 style=\"margin-bottom: 0px;\">Client</h3>\n",
-       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Client-f8192076-b135-11ee-87a3-025a5d35d49d</p>\n",
+       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Client-e3a646bb-28df-11ef-bfec-42010a800029</p>\n",
        "        <table style=\"width: 100%; text-align: left;\">\n",
        "\n",
        "        <tr>\n",
@@ -159,7 +159,7 @@
        "        \n",
        "            <tr>\n",
        "                <td style=\"text-align: left;\">\n",
-       "                    <strong>Dashboard: </strong> <a href=\"http://10.1.0.158:8787/status\" target=\"_blank\">http://10.1.0.158:8787/status</a>\n",
+       "                    <strong>Dashboard: </strong> <a href=\"http://10.128.0.41:8787/status\" target=\"_blank\">http://10.128.0.41:8787/status</a>\n",
        "                </td>\n",
        "                <td style=\"text-align: left;\"></td>\n",
        "            </tr>\n",
@@ -168,7 +168,7 @@
        "        </table>\n",
        "\n",
        "        \n",
-       "            <button style=\"margin-bottom: 12px;\" data-commandlinker-command=\"dask:populate-and-launch-layout\" data-commandlinker-args='{\"url\": \"http://10.1.0.158:8787/status\" }'>\n",
+       "            <button style=\"margin-bottom: 12px;\" data-commandlinker-command=\"dask:populate-and-launch-layout\" data-commandlinker-args='{\"url\": \"http://10.128.0.41:8787/status\" }'>\n",
        "                Launch dashboard in JupyterLab\n",
        "            </button>\n",
        "        \n",
@@ -181,11 +181,11 @@
        "    </div>\n",
        "    <div style=\"margin-left: 48px;\">\n",
        "        <h3 style=\"margin-bottom: 0px; margin-top: 0px;\">SLURMCluster</h3>\n",
-       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">221b8b7f</p>\n",
+       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">dafc234e</p>\n",
        "        <table style=\"width: 100%; text-align: left;\">\n",
        "            <tr>\n",
        "                <td style=\"text-align: left;\">\n",
-       "                    <strong>Dashboard:</strong> <a href=\"http://10.1.0.158:8787/status\" target=\"_blank\">http://10.1.0.158:8787/status</a>\n",
+       "                    <strong>Dashboard:</strong> <a href=\"http://10.128.0.41:8787/status\" target=\"_blank\">http://10.128.0.41:8787/status</a>\n",
        "                </td>\n",
        "                <td style=\"text-align: left;\">\n",
        "                    <strong>Workers:</strong> 0\n",
@@ -212,11 +212,11 @@
        "        <div style=\"width: 24px; height: 24px; background-color: #FFF7E5; border: 3px solid #FF6132; border-radius: 5px; position: absolute;\"> </div>\n",
        "        <div style=\"margin-left: 48px;\">\n",
        "            <h3 style=\"margin-bottom: 0px;\">Scheduler</h3>\n",
-       "            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-58576185-5569-4151-9038-8efa339f001e</p>\n",
+       "            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-bbb91cd8-95a6-491f-be13-75ceed506813</p>\n",
        "            <table style=\"width: 100%; text-align: left;\">\n",
        "                <tr>\n",
        "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Comm:</strong> tcp://10.1.0.158:43690\n",
+       "                        <strong>Comm:</strong> tcp://10.128.0.41:40921\n",
        "                    </td>\n",
        "                    <td style=\"text-align: left;\">\n",
        "                        <strong>Workers:</strong> 0\n",
@@ -224,7 +224,7 @@
        "                </tr>\n",
        "                <tr>\n",
        "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Dashboard:</strong> <a href=\"http://10.1.0.158:8787/status\" target=\"_blank\">http://10.1.0.158:8787/status</a>\n",
+       "                        <strong>Dashboard:</strong> <a href=\"http://10.128.0.41:8787/status\" target=\"_blank\">http://10.128.0.41:8787/status</a>\n",
        "                    </td>\n",
        "                    <td style=\"text-align: left;\">\n",
        "                        <strong>Total threads:</strong> 0\n",
@@ -262,7 +262,7 @@
        "</div>"
       ],
       "text/plain": [
-       "<Client: 'tcp://10.1.0.158:43690' processes=0 threads=0, memory=0 B>"
+       "<Client: 'tcp://10.128.0.41:40921' processes=0 threads=0, memory=0 B>"
       ]
      },
      "execution_count": 5,
@@ -320,7 +320,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "https://cloud.parallel.works/me/54885/proxy/8787/status\n"
+      "https://cloud.parallel.works/me/50447/proxy/8787/status\n"
      ]
     }
    ],
@@ -348,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "bf9ceddb-fae5-49c1-a1e5-fa4cb685a87f",
    "metadata": {
     "tags": []
@@ -385,7 +385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 9,
    "id": "b1d1455b-aafc-47c7-a358-061f002a818f",
    "metadata": {
     "tags": []
@@ -415,12 +415,16 @@
     "    output = subprocess.check_output(cmd, universal_newlines = True)\n",
     "    env_vars = json.loads(output)\n",
     "    os.environ.update(env_vars)\n",
+    "    \n",
+    "    # Return the bucket name so it can be used by the\n",
+    "    # Dask commands later.\n",
+    "    return env_vars[\"BUCKET_NAME\"] \n",
     "\n",
     "\n",
     "# REPLACE WITH YOUR BUCKET NAMESPACE\n",
     "bucket_namespace = '<USER NAME>/<BUCKET NAME>' #'alvaro/awsbucket'\n",
     "\n",
-    "load_bucket_credentials(bucket_namespace)\n",
+    "bucket_name = load_bucket_credentials(bucket_namespace)\n",
     "\n",
     "# If accessing an S3 bucket on a cluster from another \n",
     "# cloud service provider, currently you need to specify \n",
@@ -444,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "0e9b66e1-6279-4643-89e6-f85e80d7b387",
    "metadata": {
     "tags": []
@@ -464,7 +468,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "3e05b735-a7c3-4407-8582-3f10763e1fb9",
    "metadata": {
     "tags": []
@@ -486,12 +490,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "d0a98fbe-9009-42c0-af8b-035ea896127a",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['6669adb46585eae8dfed8ff0/random_data.csv']"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "csv_filename = 'random_data.csv'\n",
     "random_data.to_csv(f's3://{bucket_name}/{csv_filename}', index=False, single_file=True, storage_options=storage_options)"
@@ -508,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "4dd83f4d-ead6-4414-89bf-c54df165a6f1",
    "metadata": {},
    "outputs": [],
@@ -527,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "5e0d6ce0-851a-44c1-b2a1-ed6683a07837",
    "metadata": {},
    "outputs": [],
@@ -546,10 +561,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "4e6f94f9-62a7-466c-b059-31a7af2d3df1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['6669adb46585eae8dfed8ff0/processed_data.csv']"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "processed_csv_filename = 'processed_data.csv'\n",
     "processed_dask_df.to_csv(f's3://{bucket_name}/{processed_csv_filename}', single_file=True, storage_options=storage_options)"
@@ -565,10 +591,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "1e13f851-77cb-4be7-ae12-7c26d28422f3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "City\n",
+       "Aaronberg       4\n",
+       "Aaronborough    5\n",
+       "Aaronburgh      5\n",
+       "Aaronbury       5\n",
+       "Aaronchester    2\n",
+       "               ..\n",
+       "Zoeview         1\n",
+       "Zunigafort      2\n",
+       "Zunigaport      1\n",
+       "Zunigaside      2\n",
+       "Zunigastad      2\n",
+       "Length: 36973, dtype: int64"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Trigger computation if needed\n",
     "processed_dask_df.compute()"


### PR DESCRIPTION
This change (see line 418 in particular - the other changes are due to differences in the random bucket names and other Jupyter internals) allows the bucket name to be used by the Python code directly without having to manually specify it. The other credentials are present as env vars in the underlying shell.