### PR TITLE
fix: vnc sessions not working (black desktop) on v3 clusters

### DIFF
--- a/turbovnc/start-template.sh
+++ b/turbovnc/start-template.sh
@@ -1,10 +1,12 @@
 # Make sure no conda environment is activated! 
 # https://github.com/parallelworks/issues/issues/1081
 
-if ! [ -f /tmp/dbus.restart ]; then
-    echo Restarting dbus daemon 
-    sudo systemctl restart dbus
-    touch /tmp/dbus.restart
+if grep -q "Rocky Linux release 8" /etc/redhat-release; then
+	if ! [ -f /tmp/dbus.restart ]; then
+    	echo Restarting dbus daemon 
+    	sudo systemctl restart dbus
+    	touch /tmp/dbus.restart
+	fi
 fi
 
 # Determine if the service is running in windows using WSL

--- a/turbovnc/start-template.sh
+++ b/turbovnc/start-template.sh
@@ -1,10 +1,8 @@
 # Make sure no conda environment is activated! 
 # https://github.com/parallelworks/issues/issues/1081
 
-# davei - hack - restart the dbus daemon to fix the gnome-session crash
 if ! [ -f /tmp/dbus.restart ]; then
-
-    echo Restarting dbus daemon to hopefully avoid gnome-session crashing... -davei
+    echo Restarting dbus daemon 
     sudo systemctl restart dbus
     touch /tmp/dbus.restart
 fi

--- a/turbovnc/start-template.sh
+++ b/turbovnc/start-template.sh
@@ -1,6 +1,9 @@
 # Make sure no conda environment is activated! 
 # https://github.com/parallelworks/issues/issues/1081
 
+# davei - hack - restart the dbus daemon to fix the gnome-session crash
+echo Restarting dbus daemon to hopefully avoid gnome-session crashing... -davei
+sudo systemctl restart dbus
 
 # Determine if the service is running in windows using WSL
 kernel_version=$(uname -r | tr '[:upper:]' '[:lower:]')

--- a/turbovnc/start-template.sh
+++ b/turbovnc/start-template.sh
@@ -2,10 +2,10 @@
 # https://github.com/parallelworks/issues/issues/1081
 
 if grep -q "Rocky Linux release 8" /etc/redhat-release; then
-	if ! [ -f /tmp/dbus.restart ]; then
+	if ! [ -f /var/tmp/dbus.restart ]; then
     	echo Restarting dbus daemon 
     	sudo systemctl restart dbus
-    	touch /tmp/dbus.restart
+    	touch /var/tmp/dbus.restart
 	fi
 fi
 

--- a/turbovnc/start-template.sh
+++ b/turbovnc/start-template.sh
@@ -2,8 +2,12 @@
 # https://github.com/parallelworks/issues/issues/1081
 
 # davei - hack - restart the dbus daemon to fix the gnome-session crash
-echo Restarting dbus daemon to hopefully avoid gnome-session crashing... -davei
-sudo systemctl restart dbus
+if ! [ -f /tmp/dbus.restart ]; then
+
+    echo Restarting dbus daemon to hopefully avoid gnome-session crashing... -davei
+    sudo systemctl restart dbus
+    touch /tmp/dbus.restart
+fi
 
 # Determine if the service is running in windows using WSL
 kernel_version=$(uname -r | tr '[:upper:]' '[:lower:]')

--- a/turbovnc/start-template.sh
+++ b/turbovnc/start-template.sh
@@ -1,11 +1,13 @@
 # Make sure no conda environment is activated! 
 # https://github.com/parallelworks/issues/issues/1081
 
-if grep -q "Rocky Linux release 8" /etc/redhat-release; then
-	if ! [ -f /var/tmp/dbus.restart ]; then
-    	echo Restarting dbus daemon 
-    	sudo systemctl restart dbus
-    	touch /var/tmp/dbus.restart
+if [[ "$resource_type" != slurm* && "$resource_type" != "existing" ]]; then
+	if grep -q "Rocky Linux release 8" /etc/redhat-release; then
+		if ! [ -f /var/tmp/dbus.restart ]; then
+    		echo Restarting dbus daemon 
+    		sudo systemctl restart dbus
+    		touch /var/tmp/dbus.restart
+		fi
 	fi
 fi
 


### PR DESCRIPTION
Added checks to see if the dbus daemon hasn't been restarted since the system came up, since it seems to crash gnome-session. If it has not been, it's restarted and a file /tmp/dbus.restart is touched. The gnome session then doesn't crash and subsequent invocations of start-template.sh will not interfere with existing desktop sessions.