### PR TITLE
Include explicit resource requests for initContainter

### DIFF
--- a/workflow/yamls/jupyterlab-host/general_k8s.yaml
+++ b/workflow/yamls/jupyterlab-host/general_k8s.yaml
@@ -318,6 +318,14 @@ jobs:
                     command: ["sh", "-c", "chmod 777 ${{ inputs.k8s.volumes.pvc_mount_path }} -R"]
                     securityContext:
                       runAsUser: 0
+                    resources:
+                      requests:
+                        memory: "${{ inputs.k8s.resources.requests.memory }}"
+                        cpu: "${{ inputs.k8s.resources.requests.cpu }}"
+                      limits:
+                        memory: "${{ inputs.k8s.resources.limits.memory }}"
+                        cpu: "${{ inputs.k8s.resources.limits.cpu }}"
+                        ${gpu_limits}
                     volumeMounts:
                       - name: jupyter-storage
                         mountPath: ${{ inputs.k8s.volumes.pvc_mount_path }}


### PR DESCRIPTION
Without these requests, if you have a quota set on the namespace, the initContainer cannot start and then the main Jupyter container cannot start either.

For now, just duplicate the resource request for the main container, but it is likely that we will want to adjust the resource request for the initContainer to be smaller; it may even be hard coded since the user does not see the initContainer.