### PR TITLE
fix: module commands not found when cluster account login shell is tcsh

### DIFF
--- a/workflow/session_runner/v1.4/noaa.yaml
+++ b/workflow/session_runner/v1.4/noaa.yaml
@@ -13,7 +13,7 @@ jobs:
           # This script prepares the target host and always runs in the controller node
           cp ${{ inputs.service.inputs_sh }} ${{ inputs.service.rundir }}/controller-preprocessing-${PW_JOB_ID}.sh
           cat ${{ inputs.service.controller_script }} >> ${{ inputs.service.rundir }}/controller-preprocessing-${PW_JOB_ID}.sh
-          bash ${{ inputs.service.rundir }}/controller-preprocessing-${PW_JOB_ID}.sh
+          bash -l ${{ inputs.service.rundir }}/controller-preprocessing-${PW_JOB_ID}.sh
       - name: Create Service Script
         run: |
           rm -f HOSTNAME SESSION_PORT job.ended job.started
@@ -68,7 +68,7 @@ jobs:
         with:
           $yaml: workflow/script_submitter/v3.6/noaa.yaml
           resource: ${{ inputs.resource }}
-          shebang: '#!/bin/bash'
+          shebang: '#!/bin/bash -l'
           rundir: ${{ inputs.service.rundir }}
           use_existing_script: true
           script_path: ${{ inputs.service.rundir }}/start-service-${PW_JOB_ID}.sh


### PR DESCRIPTION
Run the controller-preprocessing and start-service scripts under a login shell (bash -l) so /etc/profile initializes the module system before the scripts eval service_install_command / service_load_env. On clusters whose account login shell is tcsh, a non-login bash leaves 'module' undefined.