### PR TITLE
fix:  transient squeue failures kill running SLURM sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,10 @@ Always use `marketplace/session_runner` (current version: `v1.3` or `v1.4`). Do 
 - `scheduler: false` → job runs on the login/controller node
 - Support both SLURM and PBS
 
+### Comments
+- Default to writing no comments. Only add one when the WHY is non-obvious: a hidden constraint, a subtle invariant, a workaround for a specific bug, or behavior that would surprise a reader. If removing the comment wouldn't confuse a future reader, don't write it.
+- Avoid WHAT comments (the code already says what), conventions that hold across the repo, and references to the current task or fix.
+
 ## Git and Deployment
 
 - Push directly to `main` branch (`git@github.com:parallelworks/interactive_session.git`)

--- a/workflow/script_submitter/v3.5/emed.yaml
+++ b/workflow/script_submitter/v3.5/emed.yaml
@@ -284,10 +284,7 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # Don't mistake a transient scheduler failure for the job ending: an
-          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
-          # otherwise fire the cleanup scancel and kill a live session. Trust
-          # squeue's exit code and sacct as the authority before tearing down.
+          # An empty squeue can be a transient slurmctld failure, not job exit; confirm via sacct before cleanup scancels a live session.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -304,7 +301,6 @@ jobs:
                 break
                 ;;
               ?*)
-                # Non-terminal or unrecognized state: the job is still alive.
                 missing_polls=0
                 continue
                 ;;

--- a/workflow/script_submitter/v3.5/emed.yaml
+++ b/workflow/script_submitter/v3.5/emed.yaml
@@ -276,17 +276,18 @@ jobs:
                   export SQUEUE_HEADER="$(eval squeue ${{ needs.preprocessing.outputs.SLURM_OPTIONS_ARG }} | awk 'NR==1')"
               fi
               status_column=$(echo "${SQUEUE_HEADER}" | awk '{ for (i=1; i<=NF; i++) if ($i ~ /^S/) { print i; exit } }')
-              status_response=$(eval squeue ${{ needs.preprocessing.outputs.SLURM_OPTIONS_ARG }} | awk -v jobid="${jobid}" '$1 == jobid')
+              squeue_output=$(eval squeue ${{ needs.preprocessing.outputs.SLURM_OPTIONS_ARG }})
+              export squeue_rc=$?
+              status_response=$(echo "${squeue_output}" | awk -v jobid="${jobid}" '$1 == jobid')
               echo "${SQUEUE_HEADER}"
               echo "${status_response}"
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
-          # Socket timed out on send/recv operation") returns no rows, which is
-          # indistinguishable from the job having ended. Treating it as an exit
-          # fires the cleanup scancel and kills a still-running session, so
-          # confirm a terminal state with sacct before tearing the session down.
+          # Don't mistake a transient scheduler failure for the job ending: an
+          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
+          # otherwise fire the cleanup scancel and kill a live session. Trust
+          # squeue's exit code and sacct as the authority before tearing down.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -296,19 +297,24 @@ jobs:
               missing_polls=0
               continue
             fi
-            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            sacct_state=$(sacct -n -X -P ${{ needs.preprocessing.outputs.SLURM_OPTIONS_ARG }} -j ${jobid} --format=state 2>/dev/null | head -n1 | awk '{print $1}')
             case "${sacct_state}" in
-              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
-                missing_polls=0
-                continue
-                ;;
-              ?*)
+              COMPLETED|FAILED|TIMEOUT|CANCELLED|NODE_FAIL|PREEMPTED|BOOT_FAIL|DEADLINE|OUT_OF_MEMORY|REVOKED)
                 echo "::notice::Job exited with status ${sacct_state}"
                 break
                 ;;
+              ?*)
+                # Non-terminal or unrecognized state: the job is still alive.
+                missing_polls=0
+                continue
+                ;;
             esac
+            if [ "${squeue_rc}" -ne 0 ]; then
+              echo "::warning::squeue query failed (exit ${squeue_rc}); retrying"
+              continue
+            fi
             missing_polls=$((missing_polls + 1))
-            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            echo "::warning::Job ${jobid} absent from squeue with no sacct record (${missing_polls}/${max_missing_polls}); retrying"
             if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
               echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               break

--- a/workflow/script_submitter/v3.5/emed.yaml
+++ b/workflow/script_submitter/v3.5/emed.yaml
@@ -282,12 +282,35 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
+          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
+          # Socket timed out on send/recv operation") returns no rows, which is
+          # indistinguishable from the job having ended. Treating it as an exit
+          # fires the cleanup scancel and kills a still-running session, so
+          # confirm a terminal state with sacct before tearing the session down.
+          missing_polls=0
+          max_missing_polls=3
           while true; do
             sleep 15
             get_slurm_job_status
-            if [ -z "${job_status}" ]; then
-              job_status=$(sacct -j ${jobid}  --format=state | tail -n1)
-              echo "::notice::Job exited with status ${job_status}"
+            if [ -n "${job_status}" ]; then
+              missing_polls=0
+              continue
+            fi
+            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            case "${sacct_state}" in
+              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
+                missing_polls=0
+                continue
+                ;;
+              ?*)
+                echo "::notice::Job exited with status ${sacct_state}"
+                break
+                ;;
+            esac
+            missing_polls=$((missing_polls + 1))
+            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
+              echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               break
             fi
           done

--- a/workflow/script_submitter/v3.5/general.yaml
+++ b/workflow/script_submitter/v3.5/general.yaml
@@ -263,10 +263,7 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # Don't mistake a transient scheduler failure for the job ending: an
-          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
-          # otherwise fire the cleanup scancel and kill a live session. Trust
-          # squeue's exit code and sacct as the authority before tearing down.
+          # An empty squeue can be a transient slurmctld failure, not job exit; confirm via sacct before cleanup scancels a live session.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -283,7 +280,6 @@ jobs:
                 break
                 ;;
               ?*)
-                # Non-terminal or unrecognized state: the job is still alive.
                 missing_polls=0
                 continue
                 ;;

--- a/workflow/script_submitter/v3.5/general.yaml
+++ b/workflow/script_submitter/v3.5/general.yaml
@@ -261,12 +261,35 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
+          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
+          # Socket timed out on send/recv operation") returns no rows, which is
+          # indistinguishable from the job having ended. Treating it as an exit
+          # fires the cleanup scancel and kills a still-running session, so
+          # confirm a terminal state with sacct before tearing the session down.
+          missing_polls=0
+          max_missing_polls=3
           while true; do
             sleep 15
             get_slurm_job_status
-            if [ -z "${job_status}" ]; then
-              job_status=$(sacct -j ${jobid}  --format=state | tail -n1)
-              echo "::notice::Job exited with status ${job_status}"
+            if [ -n "${job_status}" ]; then
+              missing_polls=0
+              continue
+            fi
+            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            case "${sacct_state}" in
+              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
+                missing_polls=0
+                continue
+                ;;
+              ?*)
+                echo "::notice::Job exited with status ${sacct_state}"
+                break
+                ;;
+            esac
+            missing_polls=$((missing_polls + 1))
+            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
+              echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               break
             fi
           done

--- a/workflow/script_submitter/v3.5/general.yaml
+++ b/workflow/script_submitter/v3.5/general.yaml
@@ -255,17 +255,18 @@ jobs:
                   export SQUEUE_HEADER="$(eval squeue | awk 'NR==1')"
               fi
               status_column=$(echo "${SQUEUE_HEADER}" | awk '{ for (i=1; i<=NF; i++) if ($i ~ /^S/) { print i; exit } }')
-              status_response=$(eval squeue | awk -v jobid="${jobid}" '$1 == jobid')
+              squeue_output=$(eval squeue)
+              export squeue_rc=$?
+              status_response=$(echo "${squeue_output}" | awk -v jobid="${jobid}" '$1 == jobid')
               echo "${SQUEUE_HEADER}"
               echo "${status_response}"
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
-          # Socket timed out on send/recv operation") returns no rows, which is
-          # indistinguishable from the job having ended. Treating it as an exit
-          # fires the cleanup scancel and kills a still-running session, so
-          # confirm a terminal state with sacct before tearing the session down.
+          # Don't mistake a transient scheduler failure for the job ending: an
+          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
+          # otherwise fire the cleanup scancel and kill a live session. Trust
+          # squeue's exit code and sacct as the authority before tearing down.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -275,19 +276,24 @@ jobs:
               missing_polls=0
               continue
             fi
-            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            sacct_state=$(sacct -n -X -P -j ${jobid} --format=state 2>/dev/null | head -n1 | awk '{print $1}')
             case "${sacct_state}" in
-              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
-                missing_polls=0
-                continue
-                ;;
-              ?*)
+              COMPLETED|FAILED|TIMEOUT|CANCELLED|NODE_FAIL|PREEMPTED|BOOT_FAIL|DEADLINE|OUT_OF_MEMORY|REVOKED)
                 echo "::notice::Job exited with status ${sacct_state}"
                 break
                 ;;
+              ?*)
+                # Non-terminal or unrecognized state: the job is still alive.
+                missing_polls=0
+                continue
+                ;;
             esac
+            if [ "${squeue_rc}" -ne 0 ]; then
+              echo "::warning::squeue query failed (exit ${squeue_rc}); retrying"
+              continue
+            fi
             missing_polls=$((missing_polls + 1))
-            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            echo "::warning::Job ${jobid} absent from squeue with no sacct record (${missing_polls}/${max_missing_polls}); retrying"
             if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
               echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               break

--- a/workflow/script_submitter/v3.5/hsp.yaml
+++ b/workflow/script_submitter/v3.5/hsp.yaml
@@ -274,10 +274,7 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # Don't mistake a transient scheduler failure for the job ending: an
-          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
-          # otherwise fire the cleanup scancel and kill a live session. Trust
-          # squeue's exit code and sacct as the authority before tearing down.
+          # An empty squeue can be a transient slurmctld failure, not job exit; confirm via sacct before cleanup scancels a live session.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -294,7 +291,6 @@ jobs:
                 break
                 ;;
               ?*)
-                # Non-terminal or unrecognized state: the job is still alive.
                 missing_polls=0
                 continue
                 ;;

--- a/workflow/script_submitter/v3.5/hsp.yaml
+++ b/workflow/script_submitter/v3.5/hsp.yaml
@@ -272,12 +272,35 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
+          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
+          # Socket timed out on send/recv operation") returns no rows, which is
+          # indistinguishable from the job having ended. Treating it as an exit
+          # fires the cleanup scancel and kills a still-running session, so
+          # confirm a terminal state with sacct before tearing the session down.
+          missing_polls=0
+          max_missing_polls=3
           while true; do
             sleep 15
             get_slurm_job_status
-            if [ -z "${job_status}" ]; then
-              job_status=$(sacct -j ${jobid}  --format=state | tail -n1)
-              echo "::notice::Job exited with status ${job_status}"
+            if [ -n "${job_status}" ]; then
+              missing_polls=0
+              continue
+            fi
+            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            case "${sacct_state}" in
+              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
+                missing_polls=0
+                continue
+                ;;
+              ?*)
+                echo "::notice::Job exited with status ${sacct_state}"
+                break
+                ;;
+            esac
+            missing_polls=$((missing_polls + 1))
+            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
+              echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               break
             fi
           done

--- a/workflow/script_submitter/v3.5/hsp.yaml
+++ b/workflow/script_submitter/v3.5/hsp.yaml
@@ -266,17 +266,18 @@ jobs:
                   export SQUEUE_HEADER="$(eval squeue | awk 'NR==1')"
               fi
               status_column=$(echo "${SQUEUE_HEADER}" | awk '{ for (i=1; i<=NF; i++) if ($i ~ /^S/) { print i; exit } }')
-              status_response=$(eval squeue | awk -v jobid="${jobid}" '$1 == jobid')
+              squeue_output=$(eval squeue)
+              export squeue_rc=$?
+              status_response=$(echo "${squeue_output}" | awk -v jobid="${jobid}" '$1 == jobid')
               echo "${SQUEUE_HEADER}"
               echo "${status_response}"
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
-          # Socket timed out on send/recv operation") returns no rows, which is
-          # indistinguishable from the job having ended. Treating it as an exit
-          # fires the cleanup scancel and kills a still-running session, so
-          # confirm a terminal state with sacct before tearing the session down.
+          # Don't mistake a transient scheduler failure for the job ending: an
+          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
+          # otherwise fire the cleanup scancel and kill a live session. Trust
+          # squeue's exit code and sacct as the authority before tearing down.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -286,19 +287,24 @@ jobs:
               missing_polls=0
               continue
             fi
-            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            sacct_state=$(sacct -n -X -P -j ${jobid} --format=state 2>/dev/null | head -n1 | awk '{print $1}')
             case "${sacct_state}" in
-              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
-                missing_polls=0
-                continue
-                ;;
-              ?*)
+              COMPLETED|FAILED|TIMEOUT|CANCELLED|NODE_FAIL|PREEMPTED|BOOT_FAIL|DEADLINE|OUT_OF_MEMORY|REVOKED)
                 echo "::notice::Job exited with status ${sacct_state}"
                 break
                 ;;
+              ?*)
+                # Non-terminal or unrecognized state: the job is still alive.
+                missing_polls=0
+                continue
+                ;;
             esac
+            if [ "${squeue_rc}" -ne 0 ]; then
+              echo "::warning::squeue query failed (exit ${squeue_rc}); retrying"
+              continue
+            fi
             missing_polls=$((missing_polls + 1))
-            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            echo "::warning::Job ${jobid} absent from squeue with no sacct record (${missing_polls}/${max_missing_polls}); retrying"
             if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
               echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               break

--- a/workflow/script_submitter/v3.5/noaa.yaml
+++ b/workflow/script_submitter/v3.5/noaa.yaml
@@ -270,10 +270,7 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # Don't mistake a transient scheduler failure for the job ending: an
-          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
-          # otherwise fire the cleanup scancel and kill a live session. Trust
-          # squeue's exit code and sacct as the authority before tearing down.
+          # An empty squeue can be a transient slurmctld failure, not job exit; confirm via sacct before cleanup scancels a live session.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -290,7 +287,6 @@ jobs:
                 break
                 ;;
               ?*)
-                # Non-terminal or unrecognized state: the job is still alive.
                 missing_polls=0
                 continue
                 ;;

--- a/workflow/script_submitter/v3.5/noaa.yaml
+++ b/workflow/script_submitter/v3.5/noaa.yaml
@@ -268,12 +268,35 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
+          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
+          # Socket timed out on send/recv operation") returns no rows, which is
+          # indistinguishable from the job having ended. Treating it as an exit
+          # fires the cleanup scancel and kills a still-running session, so
+          # confirm a terminal state with sacct before tearing the session down.
+          missing_polls=0
+          max_missing_polls=3
           while true; do
             sleep 15
             get_slurm_job_status
-            if [ -z "${job_status}" ]; then
-              job_status=$(sacct -j ${jobid}  --format=state | tail -n1)
-              echo "::notice::Job exited with status ${job_status}"
+            if [ -n "${job_status}" ]; then
+              missing_polls=0
+              continue
+            fi
+            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            case "${sacct_state}" in
+              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
+                missing_polls=0
+                continue
+                ;;
+              ?*)
+                echo "::notice::Job exited with status ${sacct_state}"
+                break
+                ;;
+            esac
+            missing_polls=$((missing_polls + 1))
+            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
+              echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               break
             fi
           done

--- a/workflow/script_submitter/v3.5/noaa.yaml
+++ b/workflow/script_submitter/v3.5/noaa.yaml
@@ -262,17 +262,18 @@ jobs:
                   export SQUEUE_HEADER="$(eval squeue | awk 'NR==1')"
               fi
               status_column=$(echo "${SQUEUE_HEADER}" | awk '{ for (i=1; i<=NF; i++) if ($i ~ /^S/) { print i; exit } }')
-              status_response=$(eval squeue | awk -v jobid="${jobid}" '$1 == jobid')
+              squeue_output=$(eval squeue)
+              export squeue_rc=$?
+              status_response=$(echo "${squeue_output}" | awk -v jobid="${jobid}" '$1 == jobid')
               echo "${SQUEUE_HEADER}"
               echo "${status_response}"
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
-          # Socket timed out on send/recv operation") returns no rows, which is
-          # indistinguishable from the job having ended. Treating it as an exit
-          # fires the cleanup scancel and kills a still-running session, so
-          # confirm a terminal state with sacct before tearing the session down.
+          # Don't mistake a transient scheduler failure for the job ending: an
+          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
+          # otherwise fire the cleanup scancel and kill a live session. Trust
+          # squeue's exit code and sacct as the authority before tearing down.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -282,19 +283,24 @@ jobs:
               missing_polls=0
               continue
             fi
-            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            sacct_state=$(sacct -n -X -P -j ${jobid} --format=state 2>/dev/null | head -n1 | awk '{print $1}')
             case "${sacct_state}" in
-              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
-                missing_polls=0
-                continue
-                ;;
-              ?*)
+              COMPLETED|FAILED|TIMEOUT|CANCELLED|NODE_FAIL|PREEMPTED|BOOT_FAIL|DEADLINE|OUT_OF_MEMORY|REVOKED)
                 echo "::notice::Job exited with status ${sacct_state}"
                 break
                 ;;
+              ?*)
+                # Non-terminal or unrecognized state: the job is still alive.
+                missing_polls=0
+                continue
+                ;;
             esac
+            if [ "${squeue_rc}" -ne 0 ]; then
+              echo "::warning::squeue query failed (exit ${squeue_rc}); retrying"
+              continue
+            fi
             missing_polls=$((missing_polls + 1))
-            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            echo "::warning::Job ${jobid} absent from squeue with no sacct record (${missing_polls}/${max_missing_polls}); retrying"
             if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
               echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               break

--- a/workflow/script_submitter/v3.6/emed.yaml
+++ b/workflow/script_submitter/v3.6/emed.yaml
@@ -289,10 +289,7 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # Don't mistake a transient scheduler failure for the job ending: an
-          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
-          # otherwise fire the cleanup scancel and kill a live session. Trust
-          # squeue's exit code and sacct as the authority before tearing down.
+          # An empty squeue can be a transient slurmctld failure, not job exit; confirm via sacct before cleanup scancels a live session.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -309,7 +306,6 @@ jobs:
                 exit 0
                 ;;
               ?*)
-                # Non-terminal or unrecognized state: the job is still alive.
                 missing_polls=0
                 continue
                 ;;

--- a/workflow/script_submitter/v3.6/emed.yaml
+++ b/workflow/script_submitter/v3.6/emed.yaml
@@ -281,17 +281,18 @@ jobs:
                   export SQUEUE_HEADER="$(eval squeue ${{ needs.preprocessing.outputs.SLURM_OPTIONS_ARG }} | awk 'NR==1')"
               fi
               status_column=$(echo "${SQUEUE_HEADER}" | awk '{ for (i=1; i<=NF; i++) if ($i ~ /^S/) { print i; exit } }')
-              status_response=$(eval squeue ${{ needs.preprocessing.outputs.SLURM_OPTIONS_ARG }} | awk -v jobid="${jobid}" '$1 == jobid')
+              squeue_output=$(eval squeue ${{ needs.preprocessing.outputs.SLURM_OPTIONS_ARG }})
+              export squeue_rc=$?
+              status_response=$(echo "${squeue_output}" | awk -v jobid="${jobid}" '$1 == jobid')
               echo "${SQUEUE_HEADER}"
               echo "${status_response}"
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
-          # Socket timed out on send/recv operation") returns no rows, which is
-          # indistinguishable from the job having ended. Treating it as an exit
-          # fires the cleanup scancel and kills a still-running session, so
-          # confirm a terminal state with sacct before tearing the session down.
+          # Don't mistake a transient scheduler failure for the job ending: an
+          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
+          # otherwise fire the cleanup scancel and kill a live session. Trust
+          # squeue's exit code and sacct as the authority before tearing down.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -301,19 +302,24 @@ jobs:
               missing_polls=0
               continue
             fi
-            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            sacct_state=$(sacct -n -X -P ${{ needs.preprocessing.outputs.SLURM_OPTIONS_ARG }} -j ${jobid} --format=state 2>/dev/null | head -n1 | awk '{print $1}')
             case "${sacct_state}" in
-              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
-                missing_polls=0
-                continue
-                ;;
-              ?*)
+              COMPLETED|FAILED|TIMEOUT|CANCELLED|NODE_FAIL|PREEMPTED|BOOT_FAIL|DEADLINE|OUT_OF_MEMORY|REVOKED)
                 echo "::notice::Job exited with status ${sacct_state}"
                 exit 0
                 ;;
+              ?*)
+                # Non-terminal or unrecognized state: the job is still alive.
+                missing_polls=0
+                continue
+                ;;
             esac
+            if [ "${squeue_rc}" -ne 0 ]; then
+              echo "::warning::squeue query failed (exit ${squeue_rc}); retrying"
+              continue
+            fi
             missing_polls=$((missing_polls + 1))
-            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            echo "::warning::Job ${jobid} absent from squeue with no sacct record (${missing_polls}/${max_missing_polls}); retrying"
             if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
               echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               exit 0

--- a/workflow/script_submitter/v3.6/emed.yaml
+++ b/workflow/script_submitter/v3.6/emed.yaml
@@ -287,12 +287,35 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
+          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
+          # Socket timed out on send/recv operation") returns no rows, which is
+          # indistinguishable from the job having ended. Treating it as an exit
+          # fires the cleanup scancel and kills a still-running session, so
+          # confirm a terminal state with sacct before tearing the session down.
+          missing_polls=0
+          max_missing_polls=3
           while true; do
             sleep 15
             get_slurm_job_status
-            if [ -z "${job_status}" ]; then
-              job_status=$(sacct -j ${jobid}  --format=state | tail -n1)
-              echo "::notice::Job exited with status ${job_status}"
+            if [ -n "${job_status}" ]; then
+              missing_polls=0
+              continue
+            fi
+            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            case "${sacct_state}" in
+              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
+                missing_polls=0
+                continue
+                ;;
+              ?*)
+                echo "::notice::Job exited with status ${sacct_state}"
+                exit 0
+                ;;
+            esac
+            missing_polls=$((missing_polls + 1))
+            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
+              echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               exit 0
             fi
           done

--- a/workflow/script_submitter/v3.6/general.yaml
+++ b/workflow/script_submitter/v3.6/general.yaml
@@ -265,12 +265,35 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
+          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
+          # Socket timed out on send/recv operation") returns no rows, which is
+          # indistinguishable from the job having ended. Treating it as an exit
+          # fires the cleanup scancel and kills a still-running session, so
+          # confirm a terminal state with sacct before tearing the session down.
+          missing_polls=0
+          max_missing_polls=3
           while true; do
             sleep 15
             get_slurm_job_status
-            if [ -z "${job_status}" ]; then
-              job_status=$(sacct -j ${jobid}  --format=state | tail -n1)
-              echo "::notice::Job exited with status ${job_status}"
+            if [ -n "${job_status}" ]; then
+              missing_polls=0
+              continue
+            fi
+            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            case "${sacct_state}" in
+              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
+                missing_polls=0
+                continue
+                ;;
+              ?*)
+                echo "::notice::Job exited with status ${sacct_state}"
+                exit 0
+                ;;
+            esac
+            missing_polls=$((missing_polls + 1))
+            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
+              echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               exit 0
             fi
           done

--- a/workflow/script_submitter/v3.6/general.yaml
+++ b/workflow/script_submitter/v3.6/general.yaml
@@ -267,10 +267,7 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # Don't mistake a transient scheduler failure for the job ending: an
-          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
-          # otherwise fire the cleanup scancel and kill a live session. Trust
-          # squeue's exit code and sacct as the authority before tearing down.
+          # An empty squeue can be a transient slurmctld failure, not job exit; confirm via sacct before cleanup scancels a live session.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -287,7 +284,6 @@ jobs:
                 exit 0
                 ;;
               ?*)
-                # Non-terminal or unrecognized state: the job is still alive.
                 missing_polls=0
                 continue
                 ;;

--- a/workflow/script_submitter/v3.6/general.yaml
+++ b/workflow/script_submitter/v3.6/general.yaml
@@ -259,17 +259,18 @@ jobs:
                   export SQUEUE_HEADER="$(eval squeue | awk 'NR==1')"
               fi
               status_column=$(echo "${SQUEUE_HEADER}" | awk '{ for (i=1; i<=NF; i++) if ($i ~ /^S/) { print i; exit } }')
-              status_response=$(eval squeue | awk -v jobid="${jobid}" '$1 == jobid')
+              squeue_output=$(eval squeue)
+              export squeue_rc=$?
+              status_response=$(echo "${squeue_output}" | awk -v jobid="${jobid}" '$1 == jobid')
               echo "${SQUEUE_HEADER}"
               echo "${status_response}"
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
-          # Socket timed out on send/recv operation") returns no rows, which is
-          # indistinguishable from the job having ended. Treating it as an exit
-          # fires the cleanup scancel and kills a still-running session, so
-          # confirm a terminal state with sacct before tearing the session down.
+          # Don't mistake a transient scheduler failure for the job ending: an
+          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
+          # otherwise fire the cleanup scancel and kill a live session. Trust
+          # squeue's exit code and sacct as the authority before tearing down.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -279,19 +280,24 @@ jobs:
               missing_polls=0
               continue
             fi
-            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            sacct_state=$(sacct -n -X -P -j ${jobid} --format=state 2>/dev/null | head -n1 | awk '{print $1}')
             case "${sacct_state}" in
-              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
-                missing_polls=0
-                continue
-                ;;
-              ?*)
+              COMPLETED|FAILED|TIMEOUT|CANCELLED|NODE_FAIL|PREEMPTED|BOOT_FAIL|DEADLINE|OUT_OF_MEMORY|REVOKED)
                 echo "::notice::Job exited with status ${sacct_state}"
                 exit 0
                 ;;
+              ?*)
+                # Non-terminal or unrecognized state: the job is still alive.
+                missing_polls=0
+                continue
+                ;;
             esac
+            if [ "${squeue_rc}" -ne 0 ]; then
+              echo "::warning::squeue query failed (exit ${squeue_rc}); retrying"
+              continue
+            fi
             missing_polls=$((missing_polls + 1))
-            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            echo "::warning::Job ${jobid} absent from squeue with no sacct record (${missing_polls}/${max_missing_polls}); retrying"
             if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
               echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               exit 0

--- a/workflow/script_submitter/v3.6/hsp.yaml
+++ b/workflow/script_submitter/v3.6/hsp.yaml
@@ -340,12 +340,35 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
+          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
+          # Socket timed out on send/recv operation") returns no rows, which is
+          # indistinguishable from the job having ended. Treating it as an exit
+          # fires the cleanup scancel and kills a still-running session, so
+          # confirm a terminal state with sacct before tearing the session down.
+          missing_polls=0
+          max_missing_polls=3
           while true; do
             sleep 15
             get_slurm_job_status
-            if [ -z "${job_status}" ]; then
-              job_status=$(sacct -j ${jobid}  --format=state | tail -n1)
-              echo "::notice::Job exited with status ${job_status}"
+            if [ -n "${job_status}" ]; then
+              missing_polls=0
+              continue
+            fi
+            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            case "${sacct_state}" in
+              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
+                missing_polls=0
+                continue
+                ;;
+              ?*)
+                echo "::notice::Job exited with status ${sacct_state}"
+                exit 0
+                ;;
+            esac
+            missing_polls=$((missing_polls + 1))
+            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
+              echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               exit 0
             fi
           done

--- a/workflow/script_submitter/v3.6/hsp.yaml
+++ b/workflow/script_submitter/v3.6/hsp.yaml
@@ -342,10 +342,7 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # Don't mistake a transient scheduler failure for the job ending: an
-          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
-          # otherwise fire the cleanup scancel and kill a live session. Trust
-          # squeue's exit code and sacct as the authority before tearing down.
+          # An empty squeue can be a transient slurmctld failure, not job exit; confirm via sacct before cleanup scancels a live session.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -362,7 +359,6 @@ jobs:
                 exit 0
                 ;;
               ?*)
-                # Non-terminal or unrecognized state: the job is still alive.
                 missing_polls=0
                 continue
                 ;;

--- a/workflow/script_submitter/v3.6/hsp.yaml
+++ b/workflow/script_submitter/v3.6/hsp.yaml
@@ -334,17 +334,18 @@ jobs:
                   export SQUEUE_HEADER="$(eval squeue | awk 'NR==1')"
               fi
               status_column=$(echo "${SQUEUE_HEADER}" | awk '{ for (i=1; i<=NF; i++) if ($i ~ /^S/) { print i; exit } }')
-              status_response=$(eval squeue | awk -v jobid="${jobid}" '$1 == jobid')
+              squeue_output=$(eval squeue)
+              export squeue_rc=$?
+              status_response=$(echo "${squeue_output}" | awk -v jobid="${jobid}" '$1 == jobid')
               echo "${SQUEUE_HEADER}"
               echo "${status_response}"
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
-          # Socket timed out on send/recv operation") returns no rows, which is
-          # indistinguishable from the job having ended. Treating it as an exit
-          # fires the cleanup scancel and kills a still-running session, so
-          # confirm a terminal state with sacct before tearing the session down.
+          # Don't mistake a transient scheduler failure for the job ending: an
+          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
+          # otherwise fire the cleanup scancel and kill a live session. Trust
+          # squeue's exit code and sacct as the authority before tearing down.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -354,19 +355,24 @@ jobs:
               missing_polls=0
               continue
             fi
-            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            sacct_state=$(sacct -n -X -P -j ${jobid} --format=state 2>/dev/null | head -n1 | awk '{print $1}')
             case "${sacct_state}" in
-              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
-                missing_polls=0
-                continue
-                ;;
-              ?*)
+              COMPLETED|FAILED|TIMEOUT|CANCELLED|NODE_FAIL|PREEMPTED|BOOT_FAIL|DEADLINE|OUT_OF_MEMORY|REVOKED)
                 echo "::notice::Job exited with status ${sacct_state}"
                 exit 0
                 ;;
+              ?*)
+                # Non-terminal or unrecognized state: the job is still alive.
+                missing_polls=0
+                continue
+                ;;
             esac
+            if [ "${squeue_rc}" -ne 0 ]; then
+              echo "::warning::squeue query failed (exit ${squeue_rc}); retrying"
+              continue
+            fi
             missing_polls=$((missing_polls + 1))
-            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            echo "::warning::Job ${jobid} absent from squeue with no sacct record (${missing_polls}/${max_missing_polls}); retrying"
             if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
               echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               exit 0

--- a/workflow/script_submitter/v3.6/noaa.yaml
+++ b/workflow/script_submitter/v3.6/noaa.yaml
@@ -275,10 +275,7 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # Don't mistake a transient scheduler failure for the job ending: an
-          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
-          # otherwise fire the cleanup scancel and kill a live session. Trust
-          # squeue's exit code and sacct as the authority before tearing down.
+          # An empty squeue can be a transient slurmctld failure, not job exit; confirm via sacct before cleanup scancels a live session.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -295,7 +292,6 @@ jobs:
                 exit 0
                 ;;
               ?*)
-                # Non-terminal or unrecognized state: the job is still alive.
                 missing_polls=0
                 continue
                 ;;

--- a/workflow/script_submitter/v3.6/noaa.yaml
+++ b/workflow/script_submitter/v3.6/noaa.yaml
@@ -273,12 +273,35 @@ jobs:
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
+          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
+          # Socket timed out on send/recv operation") returns no rows, which is
+          # indistinguishable from the job having ended. Treating it as an exit
+          # fires the cleanup scancel and kills a still-running session, so
+          # confirm a terminal state with sacct before tearing the session down.
+          missing_polls=0
+          max_missing_polls=3
           while true; do
             sleep 15
             get_slurm_job_status
-            if [ -z "${job_status}" ]; then
-              job_status=$(sacct -j ${jobid}  --format=state | tail -n1)
-              echo "::notice::Job exited with status ${job_status}"
+            if [ -n "${job_status}" ]; then
+              missing_polls=0
+              continue
+            fi
+            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            case "${sacct_state}" in
+              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
+                missing_polls=0
+                continue
+                ;;
+              ?*)
+                echo "::notice::Job exited with status ${sacct_state}"
+                exit 0
+                ;;
+            esac
+            missing_polls=$((missing_polls + 1))
+            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
+              echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               exit 0
             fi
           done

--- a/workflow/script_submitter/v3.6/noaa.yaml
+++ b/workflow/script_submitter/v3.6/noaa.yaml
@@ -267,17 +267,18 @@ jobs:
                   export SQUEUE_HEADER="$(eval squeue | awk 'NR==1')"
               fi
               status_column=$(echo "${SQUEUE_HEADER}" | awk '{ for (i=1; i<=NF; i++) if ($i ~ /^S/) { print i; exit } }')
-              status_response=$(eval squeue | awk -v jobid="${jobid}" '$1 == jobid')
+              squeue_output=$(eval squeue)
+              export squeue_rc=$?
+              status_response=$(echo "${squeue_output}" | awk -v jobid="${jobid}" '$1 == jobid')
               echo "${SQUEUE_HEADER}"
               echo "${status_response}"
               export job_status=$(echo ${status_response} | awk -v id="${jobid}" -v col="$status_column" '{print $col}')
           }
 
-          # A transient squeue/slurmctld failure (e.g. "slurm_load_jobs error:
-          # Socket timed out on send/recv operation") returns no rows, which is
-          # indistinguishable from the job having ended. Treating it as an exit
-          # fires the cleanup scancel and kills a still-running session, so
-          # confirm a terminal state with sacct before tearing the session down.
+          # Don't mistake a transient scheduler failure for the job ending: an
+          # empty squeue (e.g. "slurm_load_jobs error: Socket timed out") would
+          # otherwise fire the cleanup scancel and kill a live session. Trust
+          # squeue's exit code and sacct as the authority before tearing down.
           missing_polls=0
           max_missing_polls=3
           while true; do
@@ -287,19 +288,24 @@ jobs:
               missing_polls=0
               continue
             fi
-            sacct_state=$(sacct -n -X -j ${jobid} --format=state 2>/dev/null | head -n1 | tr -d ' ')
+            sacct_state=$(sacct -n -X -P -j ${jobid} --format=state 2>/dev/null | head -n1 | awk '{print $1}')
             case "${sacct_state}" in
-              RUNNING|PENDING|REQUEUED|RESIZING|SUSPENDED|COMPLETING|CONFIGURING)
-                missing_polls=0
-                continue
-                ;;
-              ?*)
+              COMPLETED|FAILED|TIMEOUT|CANCELLED|NODE_FAIL|PREEMPTED|BOOT_FAIL|DEADLINE|OUT_OF_MEMORY|REVOKED)
                 echo "::notice::Job exited with status ${sacct_state}"
                 exit 0
                 ;;
+              ?*)
+                # Non-terminal or unrecognized state: the job is still alive.
+                missing_polls=0
+                continue
+                ;;
             esac
+            if [ "${squeue_rc}" -ne 0 ]; then
+              echo "::warning::squeue query failed (exit ${squeue_rc}); retrying"
+              continue
+            fi
             missing_polls=$((missing_polls + 1))
-            echo "::warning::Job ${jobid} missing from squeue and sacct state unavailable (${missing_polls}/${max_missing_polls}); retrying"
+            echo "::warning::Job ${jobid} absent from squeue with no sacct record (${missing_polls}/${max_missing_polls}); retrying"
             if [ "${missing_polls}" -ge "${max_missing_polls}" ]; then
               echo "::notice::Job exited with status ${sacct_state:-UNKNOWN}"
               exit 0


### PR DESCRIPTION
## Problem

The SLURM `Monitor SLURM Job` step polls `squeue` every 15s and treated an empty result as proof the job ended → it exited, which fires the `Submit SLURM Script` cleanup hook (`scancel ... ${jobid}`) and kills the session. An empty `squeue` result also happens when `squeue` fails transiently:

```
slurm_load_jobs error: Socket timed out on send/recv operation
```

So a single slurmctld blip would `scancel` a **still-running** session. Observed in the wild: sessions `CANCELLED` (via the cleanup `scancel`, attributed to the user) hours into a multi-day allocation, with a `Socket timed out` in the monitor log right before the false "Job exited" notice. The old code even fetched the real state with `sacct`, logged `Job exited with status RUNNING`, and exited anyway.

## Fix

The monitor now treats `squeue` only as a fast-path liveness hint and uses `sacct` as the authority before tearing anything down:

- **Job listed in `squeue`** → healthy, keep monitoring.
- **Not listed** → consult `sacct`:
  - terminal state (`COMPLETED|FAILED|TIMEOUT|CANCELLED|NODE_FAIL|PREEMPTED|BOOT_FAIL|DEADLINE|OUT_OF_MEMORY|REVOKED`) → exit and let cleanup run.
  - any other / unrecognized state → treat as **still alive** and keep monitoring (fail-safe against unlisted non-terminal states like `STAGE_OUT`, `SIGNALING`, `STOPPED`, `*_HOLD`).
- **`squeue` itself errored** (non-zero exit) → transient outage, never counts toward teardown; retry.
- **`squeue` succeeded but the job is absent and `sacct` has no record** → tolerate `max_missing_polls` (3, ~45s) before concluding the job is gone.

Implementation details:
- Capture `squeue`'s exit code so a failed query is distinguished from a genuinely-gone job.
- `sacct -X -P` (parsable, allocation only — no truncation `+`) piped through `awk '{print $1}'` (first token, any whitespace, drops the `CANCELLED by <uid>` suffix) for robust state matching.
- The `emed` variant passes the cluster selector (`${{ needs.preprocessing.outputs.SLURM_OPTIONS_ARG }}`, e.g. `-M <cluster>`) to `sacct`, matching its `squeue` and the `scancel` cleanup — without it, on a multi-cluster login node whose default cluster differs from the job's, the `sacct` check would query the wrong cluster.

Applied to every SLURM `script_submitter` variant — `v3.5` and `v3.6`, for `general`, `hsp`, `emed`, and `noaa`.

## Validation

- All 8 YAML files parse; `bash -n` clean on every extracted monitor block.
- Behavioral simulation of: the incident (`squeue` socket-timeout while `sacct` says `RUNNING`), a compound `squeue`+`sacct` outage, genuine ambiguity, and real completion — the loop holds the session through transient failures and exits only on a confirmed terminal state.
- Confirmed against a live cluster: `sacct -X -P [-M <cluster>] -j <id> --format=state` returns a clean single-token state for running/cancelled jobs; `squeue` exits non-zero on a failed query but zero when a listed job has merely ended.

## Follow-up (not in this PR)

The PBS monitor (`get_pbs_job_status`) has the analogous pattern — an empty `qstat` result is treated as completion — and is worth the same hardening.
