### PR TITLE
hermes-agent: fix dashboard not connecting under Hermes v0.17 auth ha…

### DIFF
--- a/hermes-agent/start-template-v3.sh
+++ b/hermes-agent/start-template-v3.sh
@@ -63,14 +63,41 @@ export HERMES_YOLO_MODE=1
 : > "${PW_PARENT_JOB_DIR}/cancel.sh"
 
 if [ "${service_interface}" = "dashboard" ]; then
-    # Hermes' native web UI on ${service_port}. --insecure is required to bind
-    # off-loopback (the session tunnel is the access boundary). The SPA is
-    # pre-built by the controller; --skip-build avoids rebuilding on launch.
+    # Hermes' native web UI. As of the June 2026 hardening (Hermes >= v0.17.0)
+    # the dashboard REFUSES to bind off-loopback unless an auth provider is
+    # configured -- `--insecure` is now a documented no-op, not an
+    # unauthenticated public bind. The session tunnel is already the access
+    # boundary, so rather than bolt a password gate in front of it we bind the
+    # dashboard to loopback (where the auth gate does NOT engage) and put a
+    # byte-transparent TCP relay (tcp_proxy.py) on the tunnel-facing
+    # ${service_port}. The relay forwards HTTP/SSE/WebSocket and the
+    # X-Forwarded-Prefix header verbatim, so the SPA still works under the
+    # session base path -- exactly as the direct 0.0.0.0 bind did before the
+    # hardening. The controller pre-builds the SPA; --skip-build skips rebuild.
+    dash_port=$(( ${service_port} + 1 ))
     log="${PW_PARENT_JOB_DIR}/hermes-dashboard.out"
-    hermes dashboard --port "${service_port}" --host 0.0.0.0 --insecure --no-open --skip-build > "${log}" 2>&1 &
+    proxy_log="${PW_PARENT_JOB_DIR}/dashboard-proxy.out"
+    hermes dashboard --port "${dash_port}" --host 127.0.0.1 --no-open --skip-build > "${log}" 2>&1 &
     pid=$!
-    echo "kill ${pid} 2>/dev/null; pkill -P ${pid} 2>/dev/null; rm -f ${HERMES_HOME}/config.yaml" >> "${PW_PARENT_JOB_DIR}/cancel.sh"
-    echo "::notice::hermes dashboard started (pid ${pid}) on 0.0.0.0:${service_port} | log: ${log}"
+    # Expose the relay only once the loopback dashboard accepts connections, so
+    # the session readiness probe never races a not-yet-listening backend; fail
+    # loud if it never comes up (e.g. a future auth change) instead of leaving
+    # create_session to spin until timeout.
+    ready=""
+    for _ in $(seq 1 60); do
+        if curl -fsS -m 2 -o /dev/null "http://127.0.0.1:${dash_port}/"; then ready=1; break; fi
+        kill -0 "${pid}" 2>/dev/null || break
+        sleep 1
+    done
+    if [ -z "${ready}" ]; then
+        echo "::error title=Dashboard failed to start::loopback dashboard never came up; see ${log}"
+        tail -n 40 "${log}" 2>/dev/null || true
+        exit 1
+    fi
+    python3 "${AGENT_DIR}/tcp_proxy.py" --listen "0.0.0.0:${service_port}" --upstream "127.0.0.1:${dash_port}" > "${proxy_log}" 2>&1 &
+    proxy_pid=$!
+    echo "kill ${pid} ${proxy_pid} 2>/dev/null; pkill -P ${pid} 2>/dev/null; rm -f ${HERMES_HOME}/config.yaml" >> "${PW_PARENT_JOB_DIR}/cancel.sh"
+    echo "::notice::hermes dashboard started (pid ${pid}, loopback :${dash_port}) | relay pid ${proxy_pid} on 0.0.0.0:${service_port} | log: ${log}"
 else
     # OpenAI api_server (private loopback port) + key-injecting proxy on the
     # tunnel-facing port (the api_server requires a bearer the tunnel can't send).

--- a/hermes-agent/tcp_proxy.py
+++ b/hermes-agent/tcp_proxy.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Transparent TCP relay: 0.0.0.0:<listen> -> 127.0.0.1:<upstream>.
+
+Why this exists: as of the June 2026 hardening (Hermes >= v0.17.0) the dashboard
+REFUSES to bind a non-loopback address unless an auth provider (password/OAuth)
+is configured -- `--insecure` is now a documented no-op. The ACTIVATE session
+tunnel is itself the access boundary, so we don't want a second password gate in
+front of it; instead we bind the dashboard to loopback (where the auth gate does
+NOT engage) and put this relay on the tunnel-facing port `${service_port}`.
+
+A raw byte relay -- not an HTTP proxy -- is deliberate: the dashboard speaks
+HTTP, SSE, AND WebSocket (`/api/ws`, `/api/events`, a terminal socket), and it
+builds those URLs from the `X-Forwarded-Prefix` the tunnel injects so the SPA
+works under the session base path. Forwarding bytes verbatim preserves all of
+that exactly as it behaved when the dashboard bound `0.0.0.0` itself (which the
+skill verified worked, WebSockets included) -- minus the now-forbidden public
+bind. An HTTP-aware proxy would have to re-implement chunking, the WS upgrade
+handshake, and header passthrough; the relay sidesteps all of it.
+
+Standard library only (no install on the controller).
+"""
+import argparse
+import socket
+import sys
+import threading
+
+
+def _pipe(src, dst):
+    try:
+        while True:
+            data = src.recv(65536)
+            if not data:
+                break
+            dst.sendall(data)
+    except OSError:
+        pass
+    finally:
+        # Half-close the write side so the peer sees EOF but the other
+        # direction can still drain (matters for half-closed HTTP/WS streams).
+        try:
+            dst.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def _handle(client, up_host, up_port):
+    try:
+        upstream = socket.create_connection((up_host, up_port))
+    except OSError as exc:  # noqa: BLE001
+        sys.stderr.write("relay: upstream connect failed: %s\n" % exc)
+        sys.stderr.flush()
+        client.close()
+        return
+    t = threading.Thread(target=_pipe, args=(client, upstream), daemon=True)
+    t.start()
+    _pipe(upstream, client)
+    t.join()
+    client.close()
+    upstream.close()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--listen", default="0.0.0.0:8717", help="host:port to listen on (tunnel-facing)")
+    ap.add_argument("--upstream", default="127.0.0.1:9119", help="host:port of the loopback dashboard")
+    args = ap.parse_args()
+    lh, lp = args.listen.rsplit(":", 1)
+    uh, up = args.upstream.rsplit(":", 1)
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind((lh, int(lp)))
+    srv.listen(128)
+    print("tcp_proxy: %s -> %s" % (args.listen, args.upstream), flush=True)
+    while True:
+        try:
+            client, _ = srv.accept()
+        except OSError:
+            continue
+        threading.Thread(target=_handle, args=(client, uh, int(up)), daemon=True).start()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…rdening

The June 2026 hardening makes 'hermes dashboard' refuse to bind a non-loopback address without an auth provider; --insecure became a no-op. The old start script bound 0.0.0.0 with --insecure, so the dashboard exited immediately, nothing listened on ${service_port}, and the session stayed pending.

Bind the dashboard to loopback (no auth gate) and front it with a byte- transparent TCP relay (tcp_proxy.py) on the tunnel-facing port. The relay forwards HTTP/SSE/WebSocket and X-Forwarded-Prefix verbatim, so the SPA still works under the session base path -- same behavior as the pre-hardening direct bind, minus the now-forbidden public bind.